### PR TITLE
Fixes #8 - Input not working because of TMPDIR difference

### DIFF
--- a/src/commands/input/index.ts
+++ b/src/commands/input/index.ts
@@ -94,7 +94,7 @@ export async function getCmdWindowInput(
 
           // Construct the command string directly for the shell. Quotes handle paths with spaces.
           // Pass only the sessionId
-          const nodeCommand = `exec node "${escapedScriptPath}" "${escapedSessionId}"; exit 0`;
+          const nodeCommand = `exec node "${escapedScriptPath}" "${escapedSessionId}" "${tempDir}"; exit 0`;
 
           // Escape the node command for osascript's AppleScript string:
           const escapedNodeCommand = nodeCommand

--- a/src/commands/input/ui.tsx
+++ b/src/commands/input/ui.tsx
@@ -37,7 +37,11 @@ const readOptionsFromFile = async (): Promise<CmdOptions> => {
     throw new Error('No sessionId provided'); // Throw error to prevent proceeding
   }
 
-  const tempDir = os.tmpdir();
+  let tempDir = args[1];
+  if (!tempDir) {
+      tempDir = os.tmpdir();
+  }
+
   const optionsFilePath = path.join(
     tempDir,
     `cmd-ui-options-${sessionId}.json`,


### PR DESCRIPTION
```
Failed to read or parse options file /var/folders/vx/cd3sbys11nnfl2rj71r3_55r0000gn/T/cmd-ui-options-7b3b3da7c035ec10.json
```

The `os.tmpdir()` was resolved to `/tmp/` instead of the typical `/var/folders/vx/...` because Cursor is running the MCP server in somewhat simplified env

```
{
  HOME: '/Users/Martin',
  LOGNAME: 'Martin',
  PATH: '.....',
  SHELL: '/bin/zsh',
  TERM: 'xterm-256color',
  USER: 'Martin',
  WORKSPACE_FOLDER_PATHS: '/Users/Martin/.bun/install/global/node_modules/interactive-mcp',
  __CF_USER_TEXT_ENCODING: '0x1F5:0x0:0x0'
}
```

vs the `ui.js`'s process.env 
```
{"TMPDIR":"/var/folders/vx/cd3sbys11nnfl2rj71r3_55r0000gn/T/", .....}