### PR TITLE
Fix: Reliable Terminal UI launch from CLI-based LLM runtimes (macOS fallback + execPath)

### DIFF
--- a/src/commands/input/ui.tsx
+++ b/src/commands/input/ui.tsx
@@ -70,8 +70,11 @@ const readOptionsFromFile = async (): Promise<CmdOptions> => {
     } as CmdOptions;
   } catch (error) {
     logger.error(
-      `Failed to read or parse options file ${optionsFilePath}:`,
-      error instanceof Error ? error.message : error,
+      {
+        optionsFilePath,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      `Failed to read or parse options file ${optionsFilePath}`,
     );
     // Re-throw to ensure the calling code knows initialization failed
     throw error;
@@ -100,7 +103,7 @@ async function initialize() {
           // Write empty string to indicate abnormal exit (e.g., Ctrl+C)
           writeResponseToFile(options.outputFile, '')
             .catch((error) => {
-              logger.error('Failed to write exit file:', error);
+              logger.error({ error }, 'Failed to write exit file');
             })
             .finally(() => process.exit(0)); // Exit gracefully after attempting write
         } else {
@@ -114,7 +117,7 @@ async function initialize() {
       exitHandlerAttached = true;
     }
   } catch (error) {
-    logger.error('Initialization failed:', error);
+    logger.error({ error }, 'Initialization failed');
     process.exit(1); // Exit if initialization fails
   }
 }

--- a/src/commands/intensive-chat/ui.tsx
+++ b/src/commands/intensive-chat/ui.tsx
@@ -32,7 +32,10 @@ const parseArgs = () => {
       const parsed = JSON.parse(decoded);
       return { ...defaults, ...parsed };
     } catch (e) {
-      logger.error('Invalid input options payload, using defaults.', e);
+      logger.error(
+        { error: e },
+        'Invalid input options payload, using defaults.',
+      );
     }
   }
   return defaults;
@@ -70,8 +73,8 @@ const updateHeartbeat = async () => {
   } catch (writeError) {
     // Log the specific error but allow the poll cycle to continue
     logger.error(
-      `Failed to write heartbeat file ${heartbeatPath}:`,
-      writeError,
+      { heartbeatPath, error: writeError },
+      `Failed to write heartbeat file ${heartbeatPath}`,
     );
   }
 };
@@ -83,7 +86,7 @@ const handleExit = () => {
     fs.writeFile(path.join(options.outputDir, 'session-closed.txt'), '', 'utf8')
       .then(() => process.exit(0))
       .catch((error) => {
-        logger.error('Failed to write exit file:', error);
+        logger.error({ error }, 'Failed to write exit file');
         process.exit(1);
       });
   } else {
@@ -169,8 +172,8 @@ const App: FC<AppProps> = ({ sessionId, title, outputDir, timeoutSeconds }) => {
               }
             } catch (parseError) {
               logger.error(
-                `Error parsing ${sessionId}.json as JSON:`,
-                parseError,
+                { file: `${sessionId}.json`, error: parseError },
+                `Error parsing ${sessionId}.json as JSON`,
               );
             }
 
@@ -196,8 +199,8 @@ const App: FC<AppProps> = ({ sessionId, title, outputDir, timeoutSeconds }) => {
             (e as { code: unknown }).code !== 'ENOENT'
           ) {
             logger.error(
-              `Error checking/reading input file ${inputFilePath}:`,
-              e,
+              { inputFilePath, error: e },
+              `Error checking/reading input file ${inputFilePath}`,
             );
           }
           // If it's not an error with a code or the code is ENOENT, we ignore it silently.
@@ -213,7 +216,7 @@ const App: FC<AppProps> = ({ sessionId, title, outputDir, timeoutSeconds }) => {
           // No close request
         }
       } catch (error) {
-        logger.error('Error in poll cycle:', error);
+        logger.error({ error }, 'Error in poll cycle');
       }
     }, 100);
 


### PR DESCRIPTION
## Summary
- Ensures Interactive MCP opens a Terminal UI reliably when launched by CLI-based LLMs.
- Uses the exact Node binary (process.execPath) instead of relying on PATH.
- Adds macOS fallback to `open -a Terminal` via a `.command` launcher when AppleScript is blocked/fails.
- Extends startup grace period to avoid premature cleanup.

## Context / Root Cause
- Terminal UI failed to open when MCP was launched by an LLM CLI because:
  - New Terminal window didn’t inherit PATH (nvm or shell init), so `node` wasn’t found.
  - macOS Automation (AppleScript) was blocked or failed silently; no diagnostic surfaced.
  - Parent process timed out quickly and deleted the options file before UI could start.

## What’s changed
### 1) Reliable Node invocation
- Replaced `'node'` with `process.execPath` for all UI spawns (macOS, Windows, Linux).

### 2) macOS fallback launcher
- If `osascript` (tell Terminal to do script) fails or exits non-zero, write a temporary `.command` script and launch it using `open -a Terminal`:
  - `src/commands/input/index.ts`:
    - Writes launcher to: `${TMPDIR}/interactive-mcp-launch-${sessionId}.command`
    - Script: `exec "<process.execPath>" "<uiScriptPath>" "<sessionId>" "<tmpDir>"`
  - `src/commands/intensive-chat/index.ts`:
    - Writes launcher to: `<sessionDir>/interactive-mcp-intchat-${sessionId}.command`
    - Script: `exec "<process.execPath>" "<uiScriptPath>" "<base64Payload>"`

### 3) Startup grace period
- Extended heartbeat "never appeared" grace from ~7s to 60s before cleanup (input flow), so late-starting Terminal UI won't be prematurely cleaned up.

### 4) Logging and TypeScript cleanups
- Convert several `logger.error` usages to structured logs to avoid TS “unknown” issues.

## Files touched
- `src/commands/input/index.ts`
  - Use `process.execPath`
  - Add macOS `.command` fallback (`open -a Terminal`)
  - Extend heartbeat grace to 60s
  - Structured error logging
- `src/commands/intensive-chat/index.ts`
  - Use `process.execPath`
  - Add macOS `.command` fallback (`open -a Terminal`)
  - Structured error logging in `isSessionActive`
- `src/commands/input/ui.tsx`
  - Structured error logging
- `src/commands/intensive-chat/ui.tsx`
  - Structured error logging

## Testing
- Build
  - `npm run build` → Successful
- macOS (15.5)
  - With AppleScript allowed: Terminal opens via `osascript`; UI shows; responses captured.
  - With AppleScript blocked/no Automation entry: fallback kicks in; `.command` is created; Terminal opens via `open -a Terminal`; UI shows; responses captured.
- Windows/Linux
  - Spawning uses `process.execPath`; no functional regression.
  - Linux: behavior unchanged (no terminal emulator auto-open by design).

## Manual verification steps
1. Build: `npm run build`
2. Run with dev logs (optional): `NODE_ENV=development node dist/index.js`
3. Trigger request_user_input and intensive chat tools:
   - Confirm Terminal opens (AppleScript or fallback).
   - Confirm temp files (.command, heartbeat, response) are created and cleaned.

## macOS permissions notes
- Automation entries appear only after an app has requested control; fallback doesn't require Automation.
- If preferring AppleScript first, approve when prompted.

## Compatibility / Risk
- Backwards compatible:
  - `process.execPath` ensures Node resolution correctness.
  - Fallback only activates when AppleScript fails; minimal risk.
- Headless sessions can’t open windows (unchanged).

## Performance
- Negligible impact.

## Security / Privacy
- `.command` scripts only reference local absolute paths/args; no external fetches.

## Future work
- Detect and open user’s preferred terminal (iTerm2/Warp/Ghostty/WezTerm) via config `MCP_MAC_TERMINAL_APP`.
- Optional inline UI mode for headless environments (requires careful stdio handling).
- Capture `osascript` exit/stderr logs in dev mode for diagnostics.

## Release notes
- macOS: Terminal UI now opens reliably even when AppleScript is blocked. Adds fallback launcher mechanism.
- All platforms: Always run UI with the same Node binary as MCP (`process.execPath`).
- TypeScript build/logging robustness improvements.
